### PR TITLE
Addition of option command line argument to let the console output be in color text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ PROBLEM LINE FOUND! Function 'trade' in interface Factory and contract Exchange.
 This tool requires the correct Vyper compiler version to be installed. Vyper 3.10 was used for testing, which can be installed with `pip3 install vyper==0.3.10`.
 
 ```
-usage: interface-checker.py [-h] [--strict | --no-strict] [--skip-unused | --no-skip-unused] [--use-color | --no-use-color] called_contract_path caller_contract_path interface_name
+usage: interface-checker.py [-h] [--strict | --no-strict] [--skip-unused | --no-skip-unused] [--disable-color | --no-disable-color] called_contract_path caller_contract_path interface_name
 
 Run the script with: python interface-checker.py called_contract.vy caller_contract.vy interface_name
 
@@ -54,5 +54,5 @@ options:
   --skip-unused, --no-skip-unused
                         Skip checking for (low priority) unused interface definitions
   --disable-color, --no-disable-color
-                        Disable the color and bold text output to be the default console font
+                        Disable the color and bold text output to use the default console font
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ PROBLEM LINE FOUND! Function 'trade' in interface Factory and contract Exchange.
 This tool requires the correct Vyper compiler version to be installed. Vyper 3.10 was used for testing, which can be installed with `pip3 install vyper==0.3.10`.
 
 ```
-usage: interface-checker.py [-h] [--strict | --no-strict] [--skip-unused | --no-skip-unused] called_contract_path caller_contract_path interface_name
+usage: interface-checker.py [-h] [--strict | --no-strict] [--skip-unused | --no-skip-unused] [--use-color | --no-use-color] called_contract_path caller_contract_path interface_name
 
 Run the script with: python interface-checker.py called_contract.vy caller_contract.vy interface_name
 
@@ -53,4 +53,6 @@ options:
                         Only print output when there is a confirmed issue, ignore possible false positives. Do not print DONE.
   --skip-unused, --no-skip-unused
                         Skip checking for (low priority) unused interface definitions
+  ----use-color, --no-use-color
+                        Add color to the output, to enhance readability
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ options:
                         Only print output when there is a confirmed issue, ignore possible false positives. Do not print DONE.
   --skip-unused, --no-skip-unused
                         Skip checking for (low priority) unused interface definitions
-  ----use-color, --no-use-color
-                        Add color to the output, to enhance readability
+  --disable-color, --no-disable-color
+                        Disable the color and bold text output to be the default console font
 ```

--- a/interface-checker.py
+++ b/interface-checker.py
@@ -34,23 +34,23 @@ def compare_interfaces():
     parser.add_argument("interface_name", help="The name of the interface defined in caller_contract_path.vy")
     parser.add_argument("--strict", action=argparse.BooleanOptionalAction, help="Only print output when there is a confirmed issue, ignore possible false positives. Do not print DONE.")
     parser.add_argument("--skip-unused", action=argparse.BooleanOptionalAction, help="Skip checking for (low priority) unused interface definitions")
-    parser.add_argument("--use-color", action=argparse.BooleanOptionalAction, help="Add color to the output, to enhance readability")
+    parser.add_argument("--disable-color", action=argparse.BooleanOptionalAction, help="Disable the color and bold text output to be the default console font")
 
     args = parser.parse_args()
     
     # Setup Step setting up colors in the Terminal
-    if args.use_color:
-        redtext = '\033[31m'
-        purpletext = '\033[35m'
-        yellowtext = '\033[33m'
-        boldtext = '\033[1m'
-        resetfont = '\033[m'
-    else:
+    if args.disable_color:
         redtext = ''
         purpletext = ''
         yellowtext = ''
         boldtext = ''
         resetfont = ''
+    else:
+        redtext = '\033[31m'
+        purpletext = '\033[35m'
+        yellowtext = '\033[33m'
+        boldtext = '\033[1m'
+        resetfont = '\033[m'
         
     # Step 1: get the external interface for the called vyper contract
     # this is the "correct" interface of the called contract

--- a/interface-checker.py
+++ b/interface-checker.py
@@ -34,7 +34,7 @@ def compare_interfaces():
     parser.add_argument("interface_name", help="The name of the interface defined in caller_contract_path.vy")
     parser.add_argument("--strict", action=argparse.BooleanOptionalAction, help="Only print output when there is a confirmed issue, ignore possible false positives. Do not print DONE.")
     parser.add_argument("--skip-unused", action=argparse.BooleanOptionalAction, help="Skip checking for (low priority) unused interface definitions")
-    parser.add_argument("--use-color", action=argparse.BooleanOptionalAction, help="Add color to the output to help readability")
+    parser.add_argument("--use-color", action=argparse.BooleanOptionalAction, help="Add color to the output, to enhance readability")
 
     args = parser.parse_args()
     


### PR DESCRIPTION
Adding a command line argument to let the console output be in color text. 
Usage: `python interface-checker.py Exchange.vy Factory.vy Exchange --use-color`
